### PR TITLE
adds quotes around column name

### DIFF
--- a/src/ModelSearchAspect.php
+++ b/src/ModelSearchAspect.php
@@ -108,7 +108,7 @@ class ModelSearchAspect extends SearchAspect
         $query->where(function (Builder $query) use ($attributes, $term, $searchTerms) {
             foreach (Arr::wrap($attributes) as $attribute) {
                 foreach ($searchTerms as $searchTerm) {
-                    $sql = "LOWER({$attribute->getAttribute()}) LIKE ?";
+                    $sql = "LOWER(\"{$attribute->getAttribute()}\") LIKE ?";
                     $searchTerm = mb_strtolower($searchTerm, 'UTF8');
 
                     $attribute->isPartial()

--- a/tests/ModelSearchAspectTest.php
+++ b/tests/ModelSearchAspectTest.php
@@ -71,7 +71,7 @@ class ModelSearchAspectTest extends TestCase
 
         $searchAspect->getResults('john');
 
-        $expectedQuery = 'select * from "test_models" where (LOWER(name) LIKE ? or "email" = ?)';
+        $expectedQuery = 'select * from "test_models" where (LOWER("name") LIKE ? or "email" = ?)';
 
         $executedQuery = Arr::get(DB::getQueryLog(), '0.query');
 


### PR DESCRIPTION
currently query will throw exception if column name is a SQL keyword. for example if we have "to" as column name it will throw:
SQLSTATE[HY000]: General error: 1 near "to": syntax error (SQL: select * from "redirects" where (LOWER(to) LIKE %gi%))

we simply add quotes around column name to solve it.