### PR TITLE
Allow applying query scopes and eager loading relationships

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,14 +110,17 @@ $searchResults = (new Search())
    ->search('john');
 ```
 
-To get fine grained control you can also use a callable. This way you can also search for exact matches.
+To get fine grained control you can also use a callable. This way you can also search for exact matches, apply scopes, eager load relationships, or even filter your query like you would using the query builder.
 
 ```php
-$searchResults = (new Search())
+$search = (new Search())
    ->registerModel(User::class, function(ModelSearchAspect $modelSearchAspect) {
        $modelSearchAspect
           ->addSearchableAttribute('name') // return results for partial matches on usernames
-          ->addExactSearchableAttribute('email'); // only return results that exactly match the e-mail address
+          ->addExactSearchableAttribute('email') // only return results that exactly match the e-mail address
+          ->active()
+          ->has('posts')
+          ->with('roles');
 });
 ```
 

--- a/src/ModelSearchAspect.php
+++ b/src/ModelSearchAspect.php
@@ -22,7 +22,7 @@ class ModelSearchAspect extends SearchAspect
     protected $attributes = [];
 
     /** @var array */
-    public $callsToForward = [];
+    protected $callsToForward = [];
 
     public static function forModel(string $model, ...$attributes): self
     {

--- a/src/ModelSearchAspect.php
+++ b/src/ModelSearchAspect.php
@@ -7,16 +7,22 @@ use Illuminate\Support\Collection;
 use Illuminate\Foundation\Auth\User;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Support\Traits\ForwardsCalls;
 use Spatie\Searchable\Exceptions\InvalidSearchableModel;
 use Spatie\Searchable\Exceptions\InvalidModelSearchAspect;
 
 class ModelSearchAspect extends SearchAspect
 {
+    use ForwardsCalls;
+
     /** @var \Illuminate\Database\Eloquent\Model */
     protected $model;
 
     /** @var array */
     protected $attributes = [];
+
+    /** @var array */
+    public $callsToForward = [];
 
     public static function forModel(string $model, ...$attributes): self
     {
@@ -95,6 +101,10 @@ class ModelSearchAspect extends SearchAspect
 
         $query = ($this->model)::query();
 
+        foreach ($this->callsToForward as $method => $parameters) {
+            $this->forwardCallTo($query, $method, $parameters);
+        }
+
         $this->addSearchConditions($query, $term);
 
         return $query->get();
@@ -117,5 +127,12 @@ class ModelSearchAspect extends SearchAspect
                 }
             }
         });
+    }
+
+    public function __call($method, $parameters)
+    {
+        $this->callsToForward[$method] = $parameters;
+
+        return $this;
     }
 }

--- a/tests/ModelSearchAspectTest.php
+++ b/tests/ModelSearchAspectTest.php
@@ -79,7 +79,7 @@ class ModelSearchAspectTest extends TestCase
     }
 
     /** @test */
-    function it_can_build_an_eloquent_query_to_eager_load_relationships()
+    public function it_can_build_an_eloquent_query_to_eager_load_relationships()
     {
         $model = TestModel::createWithName('john');
 
@@ -92,7 +92,7 @@ class ModelSearchAspectTest extends TestCase
 
         $searchAspect->getResults('john');
 
-        $expectedQuery = 'select * from "test_comments" where "test_comments"."test_model_id" in (' . $model->id . ')';
+        $expectedQuery = 'select * from "test_comments" where "test_comments"."test_model_id" in ('.$model->id.')';
 
         $executedQuery = Arr::get(DB::getQueryLog(), '1.query');
 
@@ -100,7 +100,7 @@ class ModelSearchAspectTest extends TestCase
     }
 
     /** @test */
-    function it_can_build_an_eloquent_query_applying_scopes()
+    public function it_can_build_an_eloquent_query_applying_scopes()
     {
         $searchAspect = ModelSearchAspect::forModel(TestModel::class)
             ->addSearchableAttribute('name', true)

--- a/tests/ModelSearchAspectTest.php
+++ b/tests/ModelSearchAspectTest.php
@@ -79,6 +79,47 @@ class ModelSearchAspectTest extends TestCase
     }
 
     /** @test */
+    function it_can_build_an_eloquent_query_to_eager_load_relationships()
+    {
+        $model = TestModel::createWithName('john');
+
+        $searchAspect = ModelSearchAspect::forModel(TestModel::class)
+            ->addSearchableAttribute('name', true)
+            ->addExactSearchableAttribute('email')
+            ->with('comments');
+
+        DB::enableQueryLog();
+
+        $searchAspect->getResults('john');
+
+        $expectedQuery = 'select * from "test_comments" where "test_comments"."test_model_id" in (' . $model->id . ')';
+
+        $executedQuery = Arr::get(DB::getQueryLog(), '1.query');
+
+        $this->assertEquals($expectedQuery, $executedQuery);
+    }
+
+    /** @test */
+    function it_can_build_an_eloquent_query_applying_scopes()
+    {
+        $searchAspect = ModelSearchAspect::forModel(TestModel::class)
+            ->addSearchableAttribute('name', true)
+            ->active();
+
+        DB::enableQueryLog();
+
+        $searchAspect->getResults('john');
+
+        $expectedQuery = 'select * from "test_models" where "active" = ? and (LOWER(name) LIKE ?)';
+
+        $executedQuery = Arr::get(DB::getQueryLog(), '0.query');
+        $firstBinding = Arr::get(DB::getQueryLog(), '0.bindings.0');
+
+        $this->assertEquals($expectedQuery, $executedQuery);
+        $this->assertEquals(1, $firstBinding);
+    }
+
+    /** @test */
     public function it_has_a_type()
     {
         $searchAspect = ModelSearchAspect::forModel(TestModel::class);

--- a/tests/Models/TestComment.php
+++ b/tests/Models/TestComment.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Spatie\Searchable\Tests\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class TestComment extends Model
+{
+    protected $guarded = [];
+}

--- a/tests/Models/TestModel.php
+++ b/tests/Models/TestModel.php
@@ -5,6 +5,7 @@ namespace Spatie\Searchable\Tests\Models;
 use Spatie\Searchable\Searchable;
 use Spatie\Searchable\SearchResult;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Builder;
 
 class TestModel extends Model implements Searchable
 {
@@ -28,5 +29,15 @@ class TestModel extends Model implements Searchable
     public function getSearchResult(): SearchResult
     {
         return new SearchResult($this, $this->name);
+    }
+
+    public function comments()
+    {
+        return $this->hasMany(TestComment::class);
+    }
+
+    public function scopeActive(Builder $query)
+    {
+        $query->where('active', 1);
     }
 }

--- a/tests/SearchTest.php
+++ b/tests/SearchTest.php
@@ -29,7 +29,7 @@ class SearchTest extends TestCase
     }
 
     /** @test */
-    function it_can_apply_scopes_and_eager_load_relationships_to_a_model_search_aspect()
+    public function it_can_apply_scopes_and_eager_load_relationships_to_a_model_search_aspect()
     {
         $john = tap(TestModel::createWithName('john doe'), function ($model) {
             $model->update(['active' => true]);

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -23,6 +23,7 @@ class TestCase extends Orchestra
             $table->timestamps();
             $table->string('name');
             $table->string('last_name')->nullable();
+            $table->boolean('active')->default(false);
         });
 
         Schema::create('test_comments', function (Blueprint $table) {

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -24,5 +24,11 @@ class TestCase extends Orchestra
             $table->string('name');
             $table->string('last_name')->nullable();
         });
+
+        Schema::create('test_comments', function (Blueprint $table) {
+            $table->increments('id');
+            $table->timestamps();
+            $table->unsignedInteger('test_model_id');
+        });
     }
 }


### PR DESCRIPTION
This PR allows forwarding methods from the `ModelSearchAspect` class to the query `Builder`, when performing the query to fetch results.

That is, it allows applying scopes, eager loading relationships, or applying any filtering that would work on the query `Builder` itself.

Pagination is not supported though. Calling `paginate()` wouldn't work since we are still calling `get()` to fetch the results.

Closes #37 and #40