### PR TITLE
method signature uses 1 parameters

### DIFF
--- a/src/Search.php
+++ b/src/Search.php
@@ -58,7 +58,7 @@ class Search
 
         collect($this->getSearchAspects())
             ->each(function (SearchAspect $aspect) use ($query, $user, $searchResults) {
-                $searchResults->addResults($aspect->getType(), $aspect->getResults($query, $user));
+                $searchResults->addResults($aspect->getType(), $aspect->getResults($query));
             });
 
         return $searchResults;


### PR DESCRIPTION
Method call is provided 2 parameters, but the method signature uses 1 parameters. Besides user argument never is used 