### PR TITLE
Fix aspect on SearchResultCollection

### DIFF
--- a/src/SearchResultCollection.php
+++ b/src/SearchResultCollection.php
@@ -24,6 +24,6 @@ class SearchResultCollection extends Collection
 
     public function aspect(string $aspectName): Collection
     {
-        return $this->groupByType()->get($aspectName);
+        return $this->groupByType()->get($aspectName, collect());
     }
 }


### PR DESCRIPTION
Currently if there's no results of some type, and you try to get it, you'll get type error cause it returns null, but Collection is type-hinted.

I propose returning empty collection instead of null.