### PR TITLE
Allow to pass model object

### DIFF
--- a/src/ModelSearchAspect.php
+++ b/src/ModelSearchAspect.php
@@ -35,7 +35,7 @@ class ModelSearchAspect extends SearchAspect
      *
      * @throws \Spatie\Searchable\Exceptions\InvalidSearchableModel
      */
-    public function __construct(string $model, $attributes = [])
+    public function __construct($model, $attributes = [])
     {
         if (! is_subclass_of($model, Model::class)) {
             throw InvalidSearchableModel::notAModel($model);

--- a/src/Search.php
+++ b/src/Search.php
@@ -25,7 +25,7 @@ class Search
         return $this;
     }
 
-    public function registerModel(string $modelClass, ...$attributes): self
+    public function registerModel($modelClass, ...$attributes): self
     {
         if (isset($attributes[0]) && is_callable($attributes[0])) {
             $attributes = $attributes[0];


### PR DESCRIPTION
At the moment registerModel() allow to pass only model class name, if you pass an object that you get from User::query() then it's not working cause method registerModel() has parameter $modelClass as string.