### PR TITLE
Allow to use same query method

### DIFF
--- a/src/ModelSearchAspect.php
+++ b/src/ModelSearchAspect.php
@@ -100,8 +100,8 @@ class ModelSearchAspect extends SearchAspect
 
         $query = ($this->model)::query();
 
-        foreach ($this->callsToForward as $method => $parameters) {
-            $this->forwardCallTo($query, $method, $parameters);
+        foreach ($this->callsToForward as $callToForward) {
+            $this->forwardCallTo($query, $callToForward['method'], $callToForward['parameters']);
         }
 
         $this->addSearchConditions($query, $term);
@@ -130,7 +130,10 @@ class ModelSearchAspect extends SearchAspect
 
     public function __call($method, $parameters)
     {
-        $this->callsToForward[$method] = $parameters;
+        $this->callsToForward[] = [
+            'method'    => $method,
+            'parameters'=> $parameters,
+        ];
 
         return $this;
     }

--- a/tests/ModelSearchAspectTest.php
+++ b/tests/ModelSearchAspectTest.php
@@ -158,4 +158,25 @@ class ModelSearchAspectTest extends TestCase
 
         $searchAspect->getResults('john');
     }
+
+    /** @test */
+    public function it_can_build_an_eloquent_query_by_many_same_methods()
+    {
+        TestModel::createWithNameAndLastNameAndGenderAndStatus('Taylor', 'Otwell', 'woman', true);
+
+        $searchAspect = ModelSearchAspect::forModel(TestModel::class)
+            ->addSearchableAttribute('name', true)
+            ->where('gender', 'woman')
+            ->where('status', 'activated');
+
+        DB::enableQueryLog();
+
+        $searchAspect->getResults('taylor');
+
+        $expectedQuery = 'select * from "test_models" where "gender" = ? and "status" = ? and (LOWER(`name`) LIKE ?)';
+
+        $executedQuery = Arr::get(DB::getQueryLog(), '0.query');
+
+        $this->assertEquals($expectedQuery, $executedQuery);
+    }
 }

--- a/tests/Models/TestModel.php
+++ b/tests/Models/TestModel.php
@@ -26,6 +26,16 @@ class TestModel extends Model implements Searchable
         ]);
     }
 
+    public static function createWithNameAndLastNameAndGenderAndStatus(string $name, string $lastName, string $gender, bool $active): self
+    {
+        return static::create([
+            'name'      => $name,
+            'last_name' => $lastName,
+            'gender'    => $gender,
+            'active'    => $active,
+        ]);
+    }
+
     public function getSearchResult(): SearchResult
     {
         return new SearchResult($this, $this->name);

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -24,6 +24,7 @@ class TestCase extends Orchestra
             $table->string('name');
             $table->string('last_name')->nullable();
             $table->boolean('active')->default(false);
+            $table->string('gender')->nullable();
         });
 
         Schema::create('test_comments', function (Blueprint $table) {


### PR DESCRIPTION
In this PR enable to use same query method. solution for this issue #83 
For example
```php
// can this
$modelSearchAspect = ModelSearchAspect::forModel(Student::class)
            ->addSearchableAttribute('first_name')
            ->addSearchableAttribute('last_name')
            ->where(['gender' => 'woman', 'status' => 'activated']);
// and this
$modelSearchAspect = ModelSearchAspect::forModel(Student::class)
            ->addSearchableAttribute('first_name')
            ->addSearchableAttribute('last_name')
            ->where('gender' => 'woman')
            ->where('status', 'activated');
```

### How
The problem is when the `method` key of `callsToForward` is overwritten.
So I made it could contain the same method name with different arguments.
```php
public function __call($method, $parameters)
{
    $this->callsToForward[] = [
        'method'    => $method,
        'parameters'=> $parameters,
    ];

    return $this;
}
```
```php
public function getResults(string $term): Collection
{
    //
    //
    foreach ($this->callsToForward as $callToForward) {
        $this->forwardCallTo($query, $callToForward['method'], $callToForward['parameters']);
    }
}
```