### PR TITLE
Feature: Aspect Search Result Limit

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ It is possible to limit the amount of results returned by each aspect by calling
 ```php
 $searchResults = (new Search())
     ->registerAspect(BlogPostAspect::class)
-    ->setAspectLimit(50)
+    ->limitAspectResults(50)
     ->search('How To');
 ```
 

--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ $searchResults = (new Search())
 
 ### Limiting aspect results
 
-It is possible to limit the amount of results returned by each aspect by calling `setAspectLimit` prior to performing the search.
+It is possible to limit the amount of results returned by each aspect by calling `limitAspectResults` prior to performing the search.
 
 ```php
 $searchResults = (new Search())

--- a/README.md
+++ b/README.md
@@ -156,6 +156,17 @@ $searchResults = (new Search())
    ->search('john');
 ```
 
+### Limiting aspect results
+
+It is possible to limit the amount of results returned by each aspect by calling `setAspectLimit` prior to performing the search.
+
+```php
+$searchResults = (new Search())
+    ->registerAspect(BlogPostAspect::class)
+    ->setAspectLimit(50)
+    ->search('How To');
+```
+
 ### Rendering search results
 
 Here's an example on rendering search results:

--- a/src/ModelSearchAspect.php
+++ b/src/ModelSearchAspect.php
@@ -106,6 +106,10 @@ class ModelSearchAspect extends SearchAspect
 
         $this->addSearchConditions($query, $term);
 
+        if($this->limit) {
+            $query->limit($this->limit);
+        }
+
         return $query->get();
     }
 

--- a/src/Search.php
+++ b/src/Search.php
@@ -47,6 +47,15 @@ class Search
         return $this->aspects;
     }
 
+    public function setAspectLimit(int $limit) : self
+    {
+        collect($this->getSearchAspects())->each(function(SearchAspect $aspect) use ($limit) {
+           $aspect->limit($limit);
+        });
+
+        return $this;
+    }
+
     public function search(string $query, ?User $user = null): SearchResultCollection
     {
         return $this->perform($query, $user);

--- a/src/Search.php
+++ b/src/Search.php
@@ -47,7 +47,7 @@ class Search
         return $this->aspects;
     }
 
-    public function setAspectLimit(int $limit) : self
+    public function limitAspectResults(int $limit) : self
     {
         collect($this->getSearchAspects())->each(function(SearchAspect $aspect) use ($limit) {
            $aspect->limit($limit);

--- a/src/SearchAspect.php
+++ b/src/SearchAspect.php
@@ -7,6 +7,9 @@ use Illuminate\Support\Str;
 
 abstract class SearchAspect
 {
+    /** @var int */
+    protected $limit;
+
     abstract public function getResults(string $term): Collection;
 
     public function getType(): string
@@ -22,5 +25,10 @@ abstract class SearchAspect
         $type = Str::snake(Str::plural($type));
 
         return Str::plural($type);
+    }
+
+    public function limit($limit) : void
+    {
+        $this->limit = $limit;
     }
 }

--- a/tests/SearchTest.php
+++ b/tests/SearchTest.php
@@ -231,8 +231,7 @@ class SearchTest extends TestCase
             $modelSearchAspect
                 ->addSearchableAttribute('name');
         });
-        $results = $search->setAspectLimit(2)->perform('android');
-
+        $results = $search->limitAspectResults(2)->perform('android');
         $this->assertCount(2, $results);
     }
 
@@ -251,8 +250,7 @@ class SearchTest extends TestCase
         $search->registerAspect(CustomNameSearchAspect::class);
         // Our limiter should apply to the second aspect registered here and will make it return only 2
         $search->registerModel(TestModel::class, 'name');
-        $results = $search->setAspectLimit(2)->perform('doe');
-
+        $results = $search->limitAspectResults(2)->perform('doe');
         $this->assertCount(4, $results);
     }
 }

--- a/tests/SearchTest.php
+++ b/tests/SearchTest.php
@@ -214,4 +214,45 @@ class SearchTest extends TestCase
 
         $this->assertCount(2, $attributes);
     }
+
+    /** @test */
+    public function it_can_limit_aspect_results()
+    {
+        $search = new Search();
+
+        TestModel::createWithName('Android 16');
+        TestModel::createWithName('Android 17');
+        TestModel::createWithName('Android 18');
+        TestModel::createWithName('Android 19');
+        TestModel::createWithName('Android 20');
+        TestModel::createWithName('Android 21');
+
+        $search->registerModel(TestModel::class, function (ModelSearchAspect $modelSearchAspect) {
+            $modelSearchAspect
+                ->addSearchableAttribute('name');
+        });
+        $results = $search->setAspectLimit(2)->perform('android');
+
+        $this->assertCount(2, $results);
+    }
+
+    /** @test */
+    public function it_can_limit_multiple_aspect_results()
+    {
+        $search = new Search();
+
+        TestModel::createWithName('alex doe');
+        TestModel::createWithName('alex doe the second');
+        TestModel::createWithName('alex doe the third');
+        TestModel::createWithName('alex doe the fourth');
+        TestModel::createWithName('jenna');
+
+        // This will return 2 as it's results are hard coded
+        $search->registerAspect(CustomNameSearchAspect::class);
+        // Our limiter should apply to the second aspect registered here and will make it return only 2
+        $search->registerModel(TestModel::class, 'name');
+        $results = $search->setAspectLimit(2)->perform('doe');
+
+        $this->assertCount(4, $results);
+    }
 }


### PR DESCRIPTION
This PR makes it possible to add a limit to the number of results returned by each searchAspect by applying a limit on the query before execution. I'm introducing this to solve #56 

Usage:

```php
$searchResults = (new Search())
    ->registerAspect(BlogPostAspect::class)
    ->limitAspectResults(50)
    ->search('How To');
```

* Tests Added
* Readme Updated
* Manually verified database executes query as expected `(->setAspectLimit(2)` yields `limit 2` added to queries)