### PR TITLE
Remove backticks in SearchAspect to support PostgreSQL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to `laravel-searchable` will be documented in this file
 
+## 1.7.1 - 2020-09-08
+
+- add support for PostgreSQL
+
 ## 1.7.0 - 2020-09-08
 
 - add support for Laravel 8

--- a/src/ModelSearchAspect.php
+++ b/src/ModelSearchAspect.php
@@ -36,11 +36,11 @@ class ModelSearchAspect extends SearchAspect
      */
     public function __construct(string $model, $attributes = [])
     {
-        if (! is_subclass_of($model, Model::class)) {
+        if (!is_subclass_of($model, Model::class)) {
             throw InvalidSearchableModel::notAModel($model);
         }
 
-        if (! is_subclass_of($model, Searchable::class)) {
+        if (!is_subclass_of($model, Searchable::class)) {
             throw InvalidSearchableModel::modelDoesNotImplementSearchable($model);
         }
 
@@ -117,7 +117,7 @@ class ModelSearchAspect extends SearchAspect
         $query->where(function (Builder $query) use ($attributes, $term, $searchTerms) {
             foreach (Arr::wrap($attributes) as $attribute) {
                 foreach ($searchTerms as $searchTerm) {
-                    $sql = "LOWER(`{$attribute->getAttribute()}`) LIKE ?";
+                    $sql = "LOWER({$attribute->getAttribute()}) LIKE ?";
                     $searchTerm = mb_strtolower($searchTerm, 'UTF8');
 
                     $attribute->isPartial()

--- a/src/ModelSearchAspect.php
+++ b/src/ModelSearchAspect.php
@@ -36,11 +36,11 @@ class ModelSearchAspect extends SearchAspect
      */
     public function __construct(string $model, $attributes = [])
     {
-        if (!is_subclass_of($model, Model::class)) {
+        if (! is_subclass_of($model, Model::class)) {
             throw InvalidSearchableModel::notAModel($model);
         }
 
-        if (!is_subclass_of($model, Searchable::class)) {
+        if (! is_subclass_of($model, Searchable::class)) {
             throw InvalidSearchableModel::modelDoesNotImplementSearchable($model);
         }
 

--- a/tests/ModelSearchAspectTest.php
+++ b/tests/ModelSearchAspectTest.php
@@ -92,7 +92,7 @@ class ModelSearchAspectTest extends TestCase
 
         $searchAspect->getResults('john');
 
-        $expectedQuery = 'select * from "test_comments" where "test_comments"."test_model_id" in (' . $model->id . ')';
+        $expectedQuery = 'select * from "test_comments" where "test_comments"."test_model_id" in ('.$model->id.')';
 
         $executedQuery = Arr::get(DB::getQueryLog(), '1.query');
 
@@ -130,8 +130,7 @@ class ModelSearchAspectTest extends TestCase
     /** @test */
     public function it_throws_an_exception_when_given_a_class_that_is_not_a_model()
     {
-        $notEvenAModel = new class
-        {
+        $notEvenAModel = new class {
         };
 
         $this->expectException(InvalidSearchableModel::class);
@@ -142,8 +141,7 @@ class ModelSearchAspectTest extends TestCase
     /** @test */
     public function it_throws_an_exception_when_given_an_unsearchable_model()
     {
-        $modelWithoutSearchable = new class extends Model
-        {
+        $modelWithoutSearchable = new class extends Model {
         };
 
         $this->expectException(InvalidSearchableModel::class);

--- a/tests/ModelSearchAspectTest.php
+++ b/tests/ModelSearchAspectTest.php
@@ -71,7 +71,7 @@ class ModelSearchAspectTest extends TestCase
 
         $searchAspect->getResults('john');
 
-        $expectedQuery = 'select * from "test_models" where (LOWER(`name`) LIKE ? or "email" = ?)';
+        $expectedQuery = 'select * from "test_models" where (LOWER(name) LIKE ? or "email" = ?)';
 
         $executedQuery = Arr::get(DB::getQueryLog(), '0.query');
 
@@ -92,7 +92,7 @@ class ModelSearchAspectTest extends TestCase
 
         $searchAspect->getResults('john');
 
-        $expectedQuery = 'select * from "test_comments" where "test_comments"."test_model_id" in ('.$model->id.')';
+        $expectedQuery = 'select * from "test_comments" where "test_comments"."test_model_id" in (' . $model->id . ')';
 
         $executedQuery = Arr::get(DB::getQueryLog(), '1.query');
 
@@ -110,7 +110,7 @@ class ModelSearchAspectTest extends TestCase
 
         $searchAspect->getResults('john');
 
-        $expectedQuery = 'select * from "test_models" where "active" = ? and (LOWER(`name`) LIKE ?)';
+        $expectedQuery = 'select * from "test_models" where "active" = ? and (LOWER(name) LIKE ?)';
 
         $executedQuery = Arr::get(DB::getQueryLog(), '0.query');
         $firstBinding = Arr::get(DB::getQueryLog(), '0.bindings.0');
@@ -130,7 +130,8 @@ class ModelSearchAspectTest extends TestCase
     /** @test */
     public function it_throws_an_exception_when_given_a_class_that_is_not_a_model()
     {
-        $notEvenAModel = new class {
+        $notEvenAModel = new class
+        {
         };
 
         $this->expectException(InvalidSearchableModel::class);
@@ -141,7 +142,8 @@ class ModelSearchAspectTest extends TestCase
     /** @test */
     public function it_throws_an_exception_when_given_an_unsearchable_model()
     {
-        $modelWithoutSearchable = new class extends Model {
+        $modelWithoutSearchable = new class extends Model
+        {
         };
 
         $this->expectException(InvalidSearchableModel::class);


### PR DESCRIPTION
Removed the back-ticks and updated the tests.
Updated the CHANGELOG in case new release to be pushed with this merged

Fixes #68 #62 