### PR TITLE
tests: fix expected SQL query

### DIFF
--- a/tests/ModelSearchAspectTest.php
+++ b/tests/ModelSearchAspectTest.php
@@ -173,7 +173,7 @@ class ModelSearchAspectTest extends TestCase
 
         $searchAspect->getResults('taylor');
 
-        $expectedQuery = 'select * from "test_models" where "gender" = ? and "status" = ? and (LOWER(`name`) LIKE ?)';
+        $expectedQuery = 'select * from "test_models" where "gender" = ? and "status" = ? and (LOWER(name) LIKE ?)';
 
         $executedQuery = Arr::get(DB::getQueryLog(), '0.query');
 


### PR DESCRIPTION
This test was failing because it uses a quoted column name, whereas [the class](https://github.com/spatie/laravel-searchable/blob/329d6d507569be55541cab6eccd35651a6ce434c/src/ModelSearchAspect.php#L120) doesn't add backticks around it when building the query.