### PR TITLE
Updates to ModelSearchAspect to support multiple joins and table-prefixed search terms

### DIFF
--- a/src/ModelSearchAspect.php
+++ b/src/ModelSearchAspect.php
@@ -100,8 +100,8 @@ class ModelSearchAspect extends SearchAspect
 
         $query = ($this->model)::query();
 
-        foreach ($this->callsToForward as $method => $parameters) {
-            $this->forwardCallTo($query, $method, $parameters);
+        foreach ($this->callsToForward as $call) {
+            $this->forwardCallTo($query, $call['method'], $call['parameters']);
         }
 
         $this->addSearchConditions($query, $term);
@@ -130,7 +130,10 @@ class ModelSearchAspect extends SearchAspect
 
     public function __call($method, $parameters)
     {
-        $this->callsToForward[$method] = $parameters;
+        $this->callsToForward[] = [
+            'method' => $method,
+            'parameters' => $parameters,
+        ];
 
         return $this;
     }

--- a/src/ModelSearchAspect.php
+++ b/src/ModelSearchAspect.php
@@ -106,6 +106,10 @@ class ModelSearchAspect extends SearchAspect
 
         $this->addSearchConditions($query, $term);
 
+        if ($this->limit) {
+            $query->limit($this->limit);
+        }
+
         return $query->get();
     }
 

--- a/src/ModelSearchAspect.php
+++ b/src/ModelSearchAspect.php
@@ -117,7 +117,7 @@ class ModelSearchAspect extends SearchAspect
         $query->where(function (Builder $query) use ($attributes, $term, $searchTerms) {
             foreach (Arr::wrap($attributes) as $attribute) {
                 foreach ($searchTerms as $searchTerm) {
-                    $sql = "LOWER({$query->getGrammar()->wrap($attribute->getAttribute())}) LIKE ?";
+                    $sql = "LOWER({$query->getConnection()->getQueryGrammar()->wrap($attribute->getAttribute())}) LIKE ?";
                     $searchTerm = mb_strtolower($searchTerm, 'UTF8');
 
                     $attribute->isPartial()

--- a/src/ModelSearchAspect.php
+++ b/src/ModelSearchAspect.php
@@ -100,15 +100,11 @@ class ModelSearchAspect extends SearchAspect
 
         $query = ($this->model)::query();
 
-        foreach ($this->callsToForward as $callToForward) {
-            $this->forwardCallTo($query, $callToForward['method'], $callToForward['parameters']);
+        foreach ($this->callsToForward as $method => $parameters) {
+            $this->forwardCallTo($query, $method, $parameters);
         }
 
         $this->addSearchConditions($query, $term);
-
-        if ($this->limit) {
-            $query->limit($this->limit);
-        }
 
         return $query->get();
     }
@@ -121,7 +117,7 @@ class ModelSearchAspect extends SearchAspect
         $query->where(function (Builder $query) use ($attributes, $term, $searchTerms) {
             foreach (Arr::wrap($attributes) as $attribute) {
                 foreach ($searchTerms as $searchTerm) {
-                    $sql = "LOWER({$attribute->getAttribute()}) LIKE ?";
+                    $sql = "LOWER({$query->getGrammar()->wrap($attribute->getAttribute())}) LIKE ?";
                     $searchTerm = mb_strtolower($searchTerm, 'UTF8');
 
                     $attribute->isPartial()
@@ -134,10 +130,7 @@ class ModelSearchAspect extends SearchAspect
 
     public function __call($method, $parameters)
     {
-        $this->callsToForward[] = [
-            'method' => $method,
-            'parameters' => $parameters,
-        ];
+        $this->callsToForward[$method] = $parameters;
 
         return $this;
     }

--- a/tests/ModelSearchAspectTest.php
+++ b/tests/ModelSearchAspectTest.php
@@ -221,4 +221,25 @@ class ModelSearchAspectTest extends TestCase
 
         $searchAspect->getResults('john');
     }
+
+    /** @test */
+    public function it_can_build_an_eloquent_query_by_many_same_methods()
+    {
+        TestModel::createWithNameAndLastNameAndGenderAndStatus('Taylor', 'Otwell', 'woman', true);
+
+        $searchAspect = ModelSearchAspect::forModel(TestModel::class)
+            ->addSearchableAttribute('name', true)
+            ->where('gender', 'woman')
+            ->where('status', 'activated');
+
+        DB::enableQueryLog();
+
+        $searchAspect->getResults('taylor');
+
+        $expectedQuery = 'select * from "test_models" where "gender" = ? and "status" = ? and (LOWER(name) LIKE ?)';
+
+        $executedQuery = Arr::get(DB::getQueryLog(), '0.query');
+
+        $this->assertEquals($expectedQuery, $executedQuery);
+    }
 }

--- a/tests/ModelSearchAspectTest.php
+++ b/tests/ModelSearchAspectTest.php
@@ -227,16 +227,21 @@ class ModelSearchAspectTest extends TestCase
     {
         TestModel::createWithNameAndLastNameAndGenderAndStatus('Taylor', 'Otwell', 'woman', true);
 
+        $searchableAttribute = 'name';
         $searchAspect = ModelSearchAspect::forModel(TestModel::class)
-            ->addSearchableAttribute('name', true)
+            ->addSearchableAttribute($searchableAttribute, true)
             ->where('gender', 'woman')
             ->where('status', 'activated');
+        /** @var Connection $connection */
+        $connection = \DB::connection();
+        /** @var Grammar $grammar */
+        $grammar = $connection->getQueryGrammar();
 
         DB::enableQueryLog();
 
         $searchAspect->getResults('taylor');
 
-        $expectedQuery = 'select * from "test_models" where "gender" = ? and "status" = ? and (LOWER(name) LIKE ?)';
+        $expectedQuery = 'select * from "test_models" where "gender" = ? and "status" = ? and (LOWER(' . $grammar->wrap($searchableAttribute) . ') LIKE ?)';
 
         $executedQuery = Arr::get(DB::getQueryLog(), '0.query');
 


### PR DESCRIPTION
```
 ->registerModel(DishCategory::class, function (ModelSearchAspect $modelSearchAspect){
                /** @var \Illuminate\Database\Eloquent\Builder $query */
                $query = $modelSearchAspect
                    ->addSearchableAttribute('dishes.name');
                $query->join('dishes', 'dishes.id', '=' ,'dish_categories.dish_id')
                    ->join('categories', 'categories.id', '=' ,'dish_categories.category_id')
                    ->select('dishes.*','categories.slug as category_slug');
            })
```

for my use case (check above example)
- i needed to use a table prefix for my search term because i'm using joins (fixed by https://github.com/spatie/laravel-searchable/pull/84/commits/9e8e46cf31d295f124728d0a8f54323cf8ce3f04)
- i'm also using 2 joins so had to make sure both gets forwarded properly (fixed by https://github.com/spatie/laravel-searchable/pull/84/commits/51f562d0b04739c818b27f7ea2139c1886ece595)