### PR TITLE
Handle columns with reserved names

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -9,17 +9,12 @@ jobs:
             fail-fast: false
             matrix:
                 os: [ubuntu-latest]
-                php: [7.2, 7.3, 7.4, 8.0]
-                laravel: [8.*, 7.*]
+                php: [7.3, 7.4, 8.0]
+                laravel: [8.*]
                 dependency-version: [prefer-lowest, prefer-stable]
                 include:
                     -   laravel: 8.*
                         testbench: 6.*
-                    -   laravel: 7.*
-                        testbench: 5.*
-                exclude:
-                    -   laravel: 8.*
-                        php: 7.2
 
         name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.dependency-version }} - ${{ matrix.os }}
 

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -10,15 +10,13 @@ jobs:
             matrix:
                 os: [ubuntu-latest]
                 php: [7.2, 7.3, 7.4, 8.0]
-                laravel: [8.*, 6.*, 7.*]
+                laravel: [8.*, 7.*]
                 dependency-version: [prefer-lowest, prefer-stable]
                 include:
                     -   laravel: 8.*
                         testbench: 6.*
                     -   laravel: 7.*
                         testbench: 5.*
-                    -   laravel: 6.*
-                        testbench: 4.*
                 exclude:
                     -   laravel: 8.*
                         php: 7.2

--- a/composer.json
+++ b/composer.json
@@ -23,12 +23,12 @@
     ],
     "require": {
         "php": "^7.2|^8.0",
-        "laravel/framework": "^6.0|^7.0|^8.0"
+        "laravel/framework": "^7.0|^8.0"
     },
     "require-dev": {
-        "orchestra/testbench": "~3.8.0|^4.0|^5.0|^6.0",
+        "orchestra/testbench": "^5.0|^6.0",
         "larapack/dd": "^1.0",
-        "phpunit/phpunit": "^7.5|^8.0|^9.3"
+        "phpunit/phpunit": "^8.5|^9.3"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -22,13 +22,13 @@
         }
     ],
     "require": {
-        "php": "^7.2|^8.0",
-        "laravel/framework": "^7.0|^8.0"
+        "php": "^7.3|^8.0",
+        "laravel/framework": "^8.0"
     },
     "require-dev": {
-        "orchestra/testbench": "^5.0|^6.0",
+        "orchestra/testbench": "^6.0",
         "larapack/dd": "^1.0",
-        "phpunit/phpunit": "^8.5|^9.3"
+        "phpunit/phpunit": "^9.3"
     },
     "autoload": {
         "psr-4": {

--- a/src/ModelSearchAspect.php
+++ b/src/ModelSearchAspect.php
@@ -120,8 +120,9 @@ class ModelSearchAspect extends SearchAspect
 
         $query->where(function (Builder $query) use ($attributes, $term, $searchTerms) {
             foreach (Arr::wrap($attributes) as $attribute) {
+                $sql = "LOWER({$query->getGrammar()->wrap($attribute->getAttribute())}) LIKE ?";
+
                 foreach ($searchTerms as $searchTerm) {
-                    $sql = "LOWER({$attribute->getAttribute()}) LIKE ?";
                     $searchTerm = mb_strtolower($searchTerm, 'UTF8');
 
                     $attribute->isPartial()

--- a/tests/ModelSearchAspectTest.php
+++ b/tests/ModelSearchAspectTest.php
@@ -85,7 +85,7 @@ class ModelSearchAspectTest extends TestCase
 
         $searchAspect->getResults('john');
 
-        $expectedQuery = 'select * from "test_models" where (LOWER(name) LIKE ? or "email" = ?)';
+        $expectedQuery = 'select * from "test_models" where (LOWER("name") LIKE ? or "email" = ?)';
 
         $executedQuery = Arr::get(DB::getQueryLog(), '0.query');
 
@@ -124,7 +124,7 @@ class ModelSearchAspectTest extends TestCase
 
         $searchAspect->getResults('john');
 
-        $expectedQuery = 'select * from "test_models" where "active" = ? and (LOWER(name) LIKE ?)';
+        $expectedQuery = 'select * from "test_models" where "active" = ? and (LOWER("name") LIKE ?)';
 
         $executedQuery = Arr::get(DB::getQueryLog(), '0.query');
         $firstBinding = Arr::get(DB::getQueryLog(), '0.bindings.0');
@@ -187,7 +187,7 @@ class ModelSearchAspectTest extends TestCase
 
         $searchAspect->getResults('taylor');
 
-        $expectedQuery = 'select * from "test_models" where "gender" = ? and "status" = ? and (LOWER(name) LIKE ?)';
+        $expectedQuery = 'select * from "test_models" where "gender" = ? and "status" = ? and (LOWER("name") LIKE ?)';
 
         $executedQuery = Arr::get(DB::getQueryLog(), '0.query');
 

--- a/tests/ModelSearchAspectTest.php
+++ b/tests/ModelSearchAspectTest.php
@@ -42,6 +42,20 @@ class ModelSearchAspectTest extends TestCase
     }
 
     /** @test */
+    public function it_can_perform_a_search_on_columns_with_reserved_name()
+    {
+        TestModel::createWithNameAndLastName('jane', 'doe');
+        TestModel::createWithNameAndLastName('Taylor', 'Otwell');
+
+        $searchAspect = ModelSearchAspect::forModel(TestModel::class, 'name', 'where');
+
+        $results = $searchAspect->getResults('Taylor Otwell');
+
+        $this->assertCount(1, $results);
+        $this->assertInstanceOf(TestModel::class, $results[0]);
+    }
+
+    /** @test */
     public function it_can_add_searchable_attributes()
     {
         $searchAspect = ModelSearchAspect::forModel(TestModel::class)

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -23,6 +23,7 @@ class TestCase extends Orchestra
             $table->timestamps();
             $table->string('name');
             $table->string('last_name')->nullable();
+            $table->string('where')->nullable();
             $table->boolean('active')->default(false);
             $table->string('gender')->nullable();
         });


### PR DESCRIPTION
This PR fixes searching columns with reserved names.

The problem was that the column name was not wrapped so it failed when it found a reserved keyword.

I added a new test to prove the fix.

Since the wrapping is handled by the actual grammar it should be correct, it was checked under MySQL and SQLite and it also passed an online Postgres validator.

This PR also makes possible searching in json columns by using `column->jsonProperty` format which worked under MySQL but was broken under MariaDB.

Fixes #99 