### PR TITLE
fix: use mixin for static analysis

### DIFF
--- a/src/ModelSearchAspect.php
+++ b/src/ModelSearchAspect.php
@@ -11,6 +11,9 @@ use Illuminate\Support\Traits\ForwardsCalls;
 use Spatie\Searchable\Exceptions\InvalidModelSearchAspect;
 use Spatie\Searchable\Exceptions\InvalidSearchableModel;
 
+/**
+ * @mixin Builder
+ */
 class ModelSearchAspect extends SearchAspect
 {
     use ForwardsCalls;


### PR DESCRIPTION
The following code throws errors when you run PHPStan. This PR adds the Builder mixin which fixes the issue.

```php
->registerModel(ModelWithRelations::class, function (ModelSearchAspect $searchAspect) {
    $searchAspect->addSearchableAttribute('id')
        ->with(['relation1', 'relation2'])
        ->orderBy('id', 'desc');
})